### PR TITLE
Move to setTimeout and fix the versions of our dependencies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,15 +63,15 @@ function createCore(callback) {
 function waitForCore(result, callback) {
   try {
     if(!gencore.checkChild(result.child_pid)) {
-      // Check on the next tick round the event loop.
-      setImmediate(waitForCore, result, callback);
+      // Check again once the file has had a chance to be written.
+      setTimeout(waitForCore, 10, result, callback);
       return;
     }
   } catch (err) {
     setImmediate(callback, err);
     return;
   }
-  //console.error('Core file created!');
+
   const work_dir = result.work_dir;
   const pid = result.child_pid;
 
@@ -132,8 +132,8 @@ function collectCore(callback) {
 function waitForCoreAndCollect(result, callback) {
   try {
     if(!gencore.checkChild(result.child_pid)) {
-      // Check on the next tick round the event loop.
-      setImmediate(waitForCoreAndCollect, result, callback);
+      // Check again once the file has had a chance to be written.
+      setTimeout(waitForCoreAndCollect, 10, result, callback);
       // Return so we don't need to indent the rest of
       // this function in an else.
       return;

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Create a core dump from the currently running process without terminating or attaching a debugger.",
   "main": "index.js",
   "dependencies": {
-    "nan": "^2.3.5",
-    "fstream": ""
+    "fstream": "^1.0.11",
+    "nan": "^2.3.5"
   },
   "devDependencies": {
     "tar": "<3.0.0",
-    "tap": ""
+    "tap": "^10.5.1"
   },
   "scripts": {
     "test": "tap --timeout=300 test/test*.js"


### PR DESCRIPTION
Move from setImmeadiate to setTimeout when we are waiting.
(Don't change the error paths, they can happen immeadiately.)

Fix the versions for fstream and tap. 